### PR TITLE
Make StreamlitOauthError inherit from Exception

### DIFF
--- a/streamlit_oauth/__init__.py
+++ b/streamlit_oauth/__init__.py
@@ -26,7 +26,7 @@ else:
   _authorize_button = components.declare_component("authorize_button", path=build_dir)
 
 
-class StreamlitOauthError:
+class StreamlitOauthError(Exception):
   """
   Exception raised from streamlit-oauth.
   """


### PR DESCRIPTION
The StreamlitOauthError (in https://github.com/dnplus/streamlit-oauth/blob/main/streamlit_oauth/__init__.py#L29) is defined as:
```python
class StreamlitOauthError:
  """
  Exception raised from streamlit-oauth.
  """
```

If there is a saved state mismatch, on https://github.com/dnplus/streamlit-oauth/blob/main/streamlit_oauth/__init__.py#L98 it is raised with error text as follows: `raise StreamlitOauthError(f"STATE {state} DOES NOT MATCH OR OUT OF DATE")`

When triggered, this leads to `TypeError: StreamlitOauthError() takes no arguments`.

To resolve this, StreamlitOauthError should inherit from the built-in Exception class.