### PR TITLE
Inherit from Exception

### DIFF
--- a/streamlit_oauth/__init__.py
+++ b/streamlit_oauth/__init__.py
@@ -26,7 +26,7 @@ else:
   _authorize_button = components.declare_component("authorize_button", path=build_dir)
 
 
-class StreamlitOauthError:
+class StreamlitOauthError(Exception):
   """
   Exception raised from streamlit-oauth.
   """


### PR DESCRIPTION
Fixes

        if 'state' in result and result['state'] != state:
>         raise StreamlitOauthError(f"STATE {state} DOES NOT MATCH OR OUT OF DATE")
E         TypeError: StreamlitOauthError() takes no arguments