### PR TITLE
Fix: Preserve refresh token if not returned in OAuth refresh response

### DIFF
--- a/streamlit_oauth/__init__.py
+++ b/streamlit_oauth/__init__.py
@@ -134,7 +134,11 @@ class OAuth2Component:
       if token.get('refresh_token') is None:
         raise Exception("Token is expired and no refresh token is available")
       else:
-        token = asyncio.run(self.client.refresh_token(token.get('refresh_token')))
+        new_token = asyncio.run(self.client.refresh_token(token.get('refresh_token')))
+        # Keep the old refresh token if the new one is missing it
+        if not new_token.get('refresh_token'):
+          new_token['refresh_token'] = token.get('refresh_token')
+        token = new_token
     return token
   
   def revoke_token(self, token, token_type_hint="access_token"):

--- a/tests/test_oauth_component.py
+++ b/tests/test_oauth_component.py
@@ -48,6 +48,7 @@ def test_refresh_token_expired(monkeypatch):
     result = oauth.refresh_token(token)
 
     assert result["access_token"] == "new"
+    assert "refresh_token" in result
 
 
 def test_revoke_token(monkeypatch):


### PR DESCRIPTION
When using Google OAuth, the refresh response sometimes omits the `refresh_token` field. Without preserving the previous refresh token, users may lose the ability to refresh tokens in the future.

This PR ensures that if the refreshed token response is missing a `refresh_token`, the original one is retained.

- **Checks for a missing `refresh_token` in the new token**.
- **If missing, copies the old `refresh_token` into the new token before returning.**

This aligns with best practices for OAuth token management, and improves compatibility with Google OAuth.

Closes #87